### PR TITLE
Fix water blending-related crash

### DIFF
--- a/com.frogatto.Frogatto.yaml
+++ b/com.frogatto.Frogatto.yaml
@@ -56,6 +56,8 @@ modules:
         path: texture.patch
       - type: patch
         path: surf.patch
+      - type: patch
+        path: waterblendfix.patch
       - type: file
         path: frogatto.desktop
       - type: file

--- a/waterblendfix.patch
+++ b/waterblendfix.patch
@@ -1,0 +1,34 @@
+diff --git a/src/water.cpp b/src/water.cpp
+index d4d94d255..fc095c732 100644
+--- a/src/water.cpp
++++ b/src/water.cpp
+@@ -165,10 +165,12 @@ bool water::draw_area(const water::area& a, int x, int y, int w, int h) const
+ 	if (glBlendEquationOES) {
+ 		glBlendEquationOES(GL_FUNC_REVERSE_SUBTRACT_OES);
+ 	}
+-#elif defined(GL_OES_blend_subtract)
+-	glBlendEquationOES(GL_FUNC_REVERSE_SUBTRACT_OES);
+ #elif defined(USE_GLES2)
++#if defined(GL_OES_blend_subtract)
++	glBlendEquationOES(GL_FUNC_REVERSE_SUBTRACT_OES);
++#else
+ 	glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
++#endif
+ #else
+ 	if(GLEW_EXT_blend_equation_separate && (GLEW_ARB_imaging || GLEW_VERSION_1_4)) {
+ 		glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
+@@ -212,10 +214,12 @@ bool water::draw_area(const water::area& a, int x, int y, int w, int h) const
+ 	if (glBlendEquationOES) {
+ 		glBlendEquationOES(GL_FUNC_ADD_OES);
+ 	}
+-#elif defined(GL_OES_blend_subtract)
+-	glBlendEquationOES(GL_FUNC_ADD_OES);
+ #elif defined(USE_GLES2)
++#if defined(GL_OES_blend_subtract)
++	glBlendEquationOES(GL_FUNC_ADD_OES);
++#else
+ 	glBlendEquation(GL_FUNC_ADD);
++#endif
+ #else
+ 	if (GLEW_EXT_blend_equation_separate && (GLEW_ARB_imaging || GLEW_VERSION_1_4)) {
+ 		glBlendEquation(GL_FUNC_ADD);


### PR DESCRIPTION
Since GLEW started defining `GL_OES_blend_subtract`, the game crashes when water is used (e.g. going outside the house).

The 1.3.1 branch of Frogatto isn't maintained/updated so I'm submitting it as a patch to the flatpak build here.