### PR TITLE
Cleanup unnecessary files

### DIFF
--- a/com.frogatto.Frogatto.yaml
+++ b/com.frogatto.Frogatto.yaml
@@ -65,3 +65,9 @@ modules:
         commands:
           - cd /app/share/frogatto
           - exec /app/lib/frogatto/game "$@"
+cleanup:
+  - /share/frogatto/modules/frogatto/sounds_wav
+  - /share/frogatto/modules/frogatto/music_aac
+  - /share/frogatto/modules/frogatto/music_aac_mini
+  - /include
+  - '*.a'


### PR DESCRIPTION
Headers and static libraries don't need to be shipped, and AAC music+raw wav sound effects shouldn't be used on Linux.