### PR TITLE
update deprecated boost url

### DIFF
--- a/com.frogatto.Frogatto.yaml
+++ b/com.frogatto.Frogatto.yaml
@@ -26,7 +26,7 @@ modules:
       - ./b2 install -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2
+        url: https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.bz2
         sha256: 2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba
 
   - name: frogatto


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
